### PR TITLE
Tickets/dm 28310

### DIFF
--- a/src/org/lsst/ts/jenkins/components/Csc.groovy
+++ b/src/org/lsst/ts/jenkins/components/Csc.groovy
@@ -34,7 +34,7 @@ def build_csc_conda(label) {
         conda config --add channels conda-forge
         conda config --add channels lsstts
         source ${OSPL_HOME}/release.com
-        conda build -c lsstts/label/${label} --variants "{salobj_version: ${params.salobj_version}, idl_version: ${params.idl_version}}" --prefix-length 100 .
+        conda build -c lsstts/label/${label} --variants "{salobj_version: ${params.salobj_version}, idl_version: ${concatVersion}" --prefix-length 100 .
     """
 }
 

--- a/vars/IdlPipeline.groovy
+++ b/vars/IdlPipeline.groovy
@@ -143,7 +143,7 @@ def call(){
                             """).trim()
 
                             idl_version = "${RESULT}"
-                            echo "Starting the SalObj_Conda_package/develop job; sal_version: ${SAL_Version}, xml_version: ${XML_Version}, idl_version: ${idl_version}, develop: ${develop}, buildCSCConda: ${buildCSCConda}"
+                            echo "Starting the SalObj_Conda_package/develop job; sal_version: ${sal_ver}, xml_version: ${XML_Version}, idl_version: ${idl_version}, develop: ${develop}, buildCSCConda: ${buildCSCConda}"
                             build propagate: false, job: 'SalObj_Conda_package/tickets%252FDM-28310', parameters: [
                                 booleanParam(name: 'develop', value: "${develop}" ), 
                                 booleanParam(name: 'buildCSCConda', value: "${buildCSCConda}" ), 


### PR DESCRIPTION
changes the way variables are assembled and passed to the csc job broker, so that now IDL, XML, and SAL versions are concatenated together, with underscores between