### PR TITLE
tickets/DM-28749: Remove the .pre### string from SAL_Version, which we don't want in th…

### DIFF
--- a/Jenkinsfile.broker
+++ b/Jenkinsfile.broker
@@ -14,7 +14,10 @@ pipeline {
         booleanParam defaultValue: params.Bleed ?:false, description: 'Is this a "bleeding edge" build?', name: 'Bleed'
         booleanParam defaultValue: params.Daily ?:false, description: 'Is this a Daily build?', name: 'Daily'
         booleanParam defaultValue: params.Release ?:false, description: 'Is this a Release build?', name: 'Release'
+        booleanParam defaultValue: false, description: 'Test the broker, only trigger the Test CSC Conda job', name: 'test'
         string defaultValue: params.Branch ?:'develop', description: 'A user defined branch to use for building the CSC Conda jobs.', name: 'Branch', trim: true
+        string defaultValue: '\'\'', description: 'The XML version.', name: 'XML_Version', trim: true
+        string defaultValue: '\'\'', description: 'The SAL version.', name: 'SAL_Version', trim: true
         string defaultValue: '\'\'', description: 'The version of the IDL conda package.', name: 'idl_version', trim: true
         string defaultValue: '\'\'', description: 'The version of the SalObj conda package.', name: 'salobj_version', trim: true
     }
@@ -35,11 +38,20 @@ pipeline {
         stage('Trigger CSC Conda jobs') {
             steps {
                 script {
-                    def jobs = ['ATAOS', 'ATDome', 'ATHexapod', 'ATMCSsimulator', 'ATPneumaticssimulator', 'ATSpectrograph', 'CBP', 'DIMM', 'DSM', 
-                        'EAS', 'Electrometer', 'ESS', 'ExternalScripts', 'FiberSpectrograph', 'hexrotcomm', 'M2simulator', 'MTDome', 'MTDomeTrajectory',
-                        'MTEEC', 'MTHexapod', 'MTMount', 'MTRotator', 'ObservatoryControl', 'salkafka', 'SimActuators', 'StandardScripts', 'TunableLaser',
-                        'Watcher', 'WeatherStation']
-                        
+                    def jobs = []
+                    if (params.test) {
+                        sh "echo This is a test"
+                        jobs = ['WeatherStation']
+                    } else {
+                        jobs = ['ATAOS', 'ATDome', 'ATHexapod', 'ATMCSsimulator', 'ATPneumaticssimulator', 'ATSpectrograph', 'CBP', 'DIMM', 'DSM', 
+                            'EAS', 'Electrometer', 'ESS', 'ExternalScripts', 'FiberSpectrograph', 'hexrotcomm', 'M2simulator', 'MTDome', 'MTDomeTrajectory',
+                            'MTEEC', 'MTHexapod', 'MTMount', 'MTRotator', 'ObservatoryControl', 'salkafka', 'SimActuators', 'StandardScripts', 'TunableLaser',
+                            'Watcher', 'WeatherStation']
+                    }
+                    
+                    sal_ver = sh(returnStdout: true, script: '#!/bin/bash -x\n' + "echo ${SAL_Version} |sed 's/.pre[0-9]*//g'").trim()
+                    idl_version = "${idl_version}_${XML_Version}_${sal_ver}"
+                    salobj_version="${salobj_version}"
                     for (int i = 0; i < jobs.size(); ++i) {
                         echo "Starting the ${jobs[i]} job using the ${branch} branch and idl_version: ${idl_version}, salobj_version: ${salobj_version}"
                         build wait: false, job: "${jobs[i]}" + "_conda_package/" + branch, parameters: 

--- a/src/org/lsst/ts/jenkins/components/Csc.groovy
+++ b/src/org/lsst/ts/jenkins/components/Csc.groovy
@@ -39,6 +39,7 @@ def build_idl_conda(label) {
         echo 'The SAL version: ${params.SAL_Version}'
         echo 'The BuildType: ${params.build_type}'
     """
+    echo "The TS_SAL_VERSION EnvVar: ${env.TS_SAL_VERSION}"
     if ( params.build_type == "Bleed" ) {
         rpm_repo = "lsst-ts-bleed"
     } else if ( params.build_type == "Daily" ) {

--- a/vars/IdlPipeline.groovy
+++ b/vars/IdlPipeline.groovy
@@ -43,12 +43,24 @@ def call(){
             booleanParam(defaultValue: false, description: "Are we going on to building the CSC package after salobj?", name: 'buildCSCConda')
         }
         stages {
+            stage("Define TS_SAL_VERSION EnvVar") {
+                steps {
+                    echo 'Remove .pre### extension from TS_SAL_VERSION EnvVar.'
+                    script {
+                        sal_ver = sh(returnStdout: true, script: '#!/bin/bash -x\n' +
+                            "echo ${params.SAL_Version} |sed 's/.pre[0-9]*//g'").trim()
+                        sh "echo 'sal_ver: ${sal_ver}'"
+                        env.TS_SAL_VERSION = "${sal_ver}"
+                    }
+                    echo "TS_SAL_VERSION: ${env.TS_SAL_VERSION}"
+                }
+            }
             stage("Create Conda Package") {
                 when {
                     buildingTag()
                 }
                 steps {
-                    withEnv(["HOME=${env.WORKSPACE}"]) {
+                    withEnv(["HOME=${env.WORKSPACE}", "TS_SAL_VERSION=${env.TS_SAL_VERSION}"]) {
                         script {
                             csc.build_idl_conda("main")
                         }
@@ -130,12 +142,14 @@ def call(){
                             python -c 'from setuptools_scm import get_version; print(get_version())'
                             """).trim()
 
-                            idl_version = "${RESULT}" + "_" + "${XML_Version}" + "_" + "${SAL_Version}"
+                            idl_version = "${RESULT}"
                             echo "Starting the SalObj_Conda_package/develop job; sal_version: ${SAL_Version}, xml_version: ${XML_Version}, idl_version: ${idl_version}, develop: ${develop}, buildCSCConda: ${buildCSCConda}"
-                            build propagate: false, job: 'SalObj_Conda_package/develop', parameters: [
+                            build propagate: false, job: 'SalObj_Conda_package/tickets%252FDM-28310', parameters: [
                                 booleanParam(name: 'develop', value: "${develop}" ), 
                                 booleanParam(name: 'buildCSCConda', value: "${buildCSCConda}" ), 
-                                string(name: 'idl_version',value: "${idl_version}" )
+                                string(name: 'idl_version',value: "${idl_version}" ), 
+                                string(name: 'xml_version',value: "${XML_Version}" ), 
+                                string(name: 'sal_version',value: "${sal_ver}" )
                             ], wait: false
                     }
                 }


### PR DESCRIPTION
…e IDL version.

Append XML and SAL version (without the .pre### string) to idl_version.

Add a test parameter to Jenkinsfile.broker to only trigger one CSC Conda job.

Set the XML and SAL version build parameters when triggering the SalObj_Conda_package job.