### PR TITLE
DM-29685: Cycle 0019 support

### DIFF
--- a/src/org/lsst/ts/jenkins/components/Csc.groovy
+++ b/src/org/lsst/ts/jenkins/components/Csc.groovy
@@ -34,11 +34,10 @@ def test() {
 def build_csc_conda(label) {
     // Build the conda package
     sh """
-        cd ${HOME}/conda
-        source /home/saluser/miniconda3/bin/activate
+        cd ${WHOME}/conda
+        source /home/saluser/.setup.sh
         conda config --add channels conda-forge
         conda config --add channels lsstts
-        source ${OSPL_HOME}/release.com
         conda build -c lsstts/label/${label} --variants "{salobj_version: ${params.salobj_version}, idl_version: ${params.idl_version}}" --prefix-length 100 .
     """
 }
@@ -71,24 +70,22 @@ def build_idl_conda(label) {
         }
     }
     sh """
-        # yum clean all ; yum makecache fast; yum update ; 
+        # yum clean all ; yum makecache fast; yum update ;
         yum install -y --enablerepo=${rpm_repo} ts_sal_runtime-${params.XML_Version}-${params.SAL_Version}.el7.x86_64
-        cd ${HOME}/conda
-        source /home/saluser/miniconda3/bin/activate 
+        cd ${WHOME}/conda
+        source /home/saluser/.setup.sh
         conda config --add channels conda-forge
         conda config --add channels lsstts
-        source ${OSPL_HOME}/release.com
         conda build -c lsstts/label/${label} --prefix-length 100 .
     """
 }
 
 def build_salobj_conda(label, concatVersion) {
     sh """
-        cd ${HOME}/conda
-        source /home/saluser/miniconda3/bin/activate
+        cd ${WHOME}/conda
+        source /home/saluser/.setup.sh
         conda config --add channels conda-forge
         conda config --add channels lsstts
-        source ${OSPL_HOME}/release.com
         conda build -c lsstts/label/${label} --variants "{idl_version: ${concatVersion}}" --prefix-length 100 .
     """
 }
@@ -98,8 +95,8 @@ def upload_conda(name, label, arch) {
     // Takes the name of the package and a label
     if ((arch=="linux-aarch64") || (arch=="noarch") || (arch=="linux-64")) {
         sh """
-            source /home/saluser/miniconda3/bin/activate
-            anaconda upload -u lsstts --label ${label} --force /home/saluser/miniconda3/conda-bld/${arch}/${name}*.tar.bz2    
+            source /home/saluser/.setup.sh
+            anaconda upload -u lsstts --label ${label} --force /home/saluser/miniconda3/conda-bld/${arch}/${name}*.tar.bz2
         """
     }
     else {
@@ -110,12 +107,11 @@ def upload_conda(name, label, arch) {
 
 def upload_pypi() {
     sh """
-        source /home/saluser/miniconda3/bin/activate
-        source ${OSPL_HOME}/release.com
+        source /home/saluser/.setup.sh
         pip install --upgrade twine
         python setup.py sdist bdist_wheel
         python -m twine upload -u ${env.PYPI_CREDS_USR} -p ${env.PYPI_CREDS_PSW} dist/*
-    """ 
+    """
 }
 
 return this

--- a/vars/CondaPipeline.groovy
+++ b/vars/CondaPipeline.groovy
@@ -7,12 +7,6 @@ def call(config_repo, name, module_name,arch="linux-64"){
     slack_ids = csc.slack_id()
     arg_str = ""
     clone_str = ""
-    if (arch!="linux-aarch64") {
-        ospl_home = "/opt/OpenSpliceDDS/V6.10.4/HDE/x86_64.linux"
-    }
-    else {
-        ospl_home = "/opt/OpenSpliceDDS/V6.9.0/HDE/aarch64.linux"
-    }
     if (!config_repo.isEmpty()) {
         config_repo.each{ repo ->
             arg_str = arg_str.concat("--env ${repo.toUpperCase()}_DIR=/home/saluser/${repo} ")
@@ -63,11 +57,10 @@ def call(config_repo, name, module_name,arch="linux-64"){
         }
         environment {
             package_name = "${name}"
-            OSPL_HOME="${ospl_home}"
         }
         options {
             disableConcurrentBuilds()
-        }    
+        }
         stages {
             stage("Clone configuration repository") {
                 when {
@@ -91,7 +84,7 @@ def call(config_repo, name, module_name,arch="linux-64"){
                     buildingTag()
                 }
                 steps {
-                    withEnv(["HOME=${env.WORKSPACE}"]) {
+                    withEnv(["WHOME=${env.WORKSPACE}"]) {
                         script {
                             csc.build_csc_conda("main")
                         }
@@ -105,7 +98,7 @@ def call(config_repo, name, module_name,arch="linux-64"){
                     }
                 }
                 steps {
-                    withEnv(["HOME=${env.WORKSPACE}"]) {
+                    withEnv(["WHOME=${env.WORKSPACE}"]) {
                         script {
                             csc.build_csc_conda("dev")
                         }
@@ -119,7 +112,7 @@ def call(config_repo, name, module_name,arch="linux-64"){
                 }
                 steps {
                     withCredentials([usernamePassword(credentialsId: 'CondaForge', passwordVariable: 'anaconda_pass', usernameVariable: 'anaconda_user')]) {
-                        withEnv(["HOME=${env.WORKSPACE}"]) {
+                        withEnv(["WHOME=${env.WORKSPACE}"]) {
                             sh """
                             source /home/saluser/miniconda3/bin/activate
                             anaconda login --user ${anaconda_user} --password ${anaconda_pass}
@@ -140,7 +133,7 @@ def call(config_repo, name, module_name,arch="linux-64"){
                 }
                 steps {
                     withCredentials([usernamePassword(credentialsId: 'CondaForge', passwordVariable: 'anaconda_pass', usernameVariable: 'anaconda_user')]) {
-                        withEnv(["HOME=${env.WORKSPACE}"]) {
+                        withEnv(["WHOME=${env.WORKSPACE}"]) {
                             sh """
                             source /home/saluser/miniconda3/bin/activate
                             anaconda login --user ${anaconda_user} --password ${anaconda_pass}
@@ -165,7 +158,7 @@ def call(config_repo, name, module_name,arch="linux-64"){
                     def userId = slack_ids[name]
                     slackSend(color: "danger", message: "<@$userId> ${JOB_NAME} has suffered a regression ${BUILD_URL}", channel: "#jenkins-builds, @$userId")
                 }
-                
+
             }
             fixed {
                 script {

--- a/vars/IdlPipeline.groovy
+++ b/vars/IdlPipeline.groovy
@@ -27,12 +27,9 @@ def call(){
         }
         options {
             disableConcurrentBuilds()
-        }    
+        }
         environment {
-            dockerImageName = "lsstts/conda_package_builder:latest"
-            container_name = "idl_${BUILD_ID}_${JENKINS_NODE_COOKIE}"
             PYPI_CREDS = credentials("pypi")
-            OSPL_HOME="/opt/OpenSpliceDDS/V6.10.4/HDE/x86_64.linux"
         }
         parameters {
             string(defaultValue: '7.1.0', description: 'The XML Version, exclude any preceeding "v" characters: X.Y.Z', name: 'XML_Version')
@@ -60,7 +57,7 @@ def call(){
                     buildingTag()
                 }
                 steps {
-                    withEnv(["HOME=${env.WORKSPACE}", "TS_SAL_VERSION=${env.TS_SAL_VERSION}"]) {
+                    withEnv(["WHOME=${env.WORKSPACE}", "TS_SAL_VERSION=${env.TS_SAL_VERSION}"]) {
                         script {
                             csc.build_idl_conda("main")
                         }
@@ -74,7 +71,7 @@ def call(){
                     }
                 }
                 steps {
-                    withEnv(["HOME=${env.WORKSPACE}"]) {
+                    withEnv(["WHOME=${env.WORKSPACE}"]) {
                         script {
                             csc.build_idl_conda("dev")
                         }
@@ -90,7 +87,7 @@ def call(){
                 }
                 steps {
                     withCredentials([usernamePassword(credentialsId: 'CondaForge', passwordVariable: 'anaconda_pass', usernameVariable: 'anaconda_user')]) {
-                        withEnv(["HOME=${env.WORKSPACE}"]) {
+                        withEnv(["WHOME=${env.WORKSPACE}"]) {
                             sh """
                             source /home/saluser/miniconda3/bin/activate
                             anaconda login --user ${anaconda_user} --password ${anaconda_pass}
@@ -110,7 +107,7 @@ def call(){
                 }
                 steps {
                     withCredentials([usernamePassword(credentialsId: 'CondaForge', passwordVariable: 'anaconda_pass', usernameVariable: 'anaconda_user')]) {
-                        withEnv(["HOME=${env.WORKSPACE}"]) {
+                        withEnv(["WHOME=${env.WORKSPACE}"]) {
                             sh """
                             source /home/saluser/miniconda3/bin/activate
                             anaconda login --user ${anaconda_user} --password ${anaconda_pass}
@@ -145,10 +142,10 @@ def call(){
                             idl_version = "${RESULT}"
                             echo "Starting the SalObj_Conda_package/develop job; sal_version: ${sal_ver}, xml_version: ${XML_Version}, idl_version: ${idl_version}, develop: ${develop}, buildCSCConda: ${buildCSCConda}"
                             build propagate: false, job: 'SalObj_Conda_package/develop', parameters: [
-                                booleanParam(name: 'develop', value: "${develop}" ), 
-                                booleanParam(name: 'buildCSCConda', value: "${buildCSCConda}" ), 
-                                string(name: 'idl_version',value: "${idl_version}" ), 
-                                string(name: 'xml_version',value: "${XML_Version}" ), 
+                                booleanParam(name: 'develop', value: "${develop}" ),
+                                booleanParam(name: 'buildCSCConda', value: "${buildCSCConda}" ),
+                                string(name: 'idl_version',value: "${idl_version}" ),
+                                string(name: 'xml_version',value: "${XML_Version}" ),
                                 string(name: 'sal_version',value: "${sal_ver}" )
                             ], wait: false
                     }
@@ -173,7 +170,7 @@ def call(){
                     def userId = "U6BCN6H43"
                     slackSend(color: "danger", message: "<@$userId> ${JOB_NAME} has suffered a regression ${BUILD_URL}", channel: "#jenkins-builds, @$userId")
                 }
-                
+
             }
             fixed {
                 script {

--- a/vars/SalobjPipeline.groovy
+++ b/vars/SalobjPipeline.groovy
@@ -37,19 +37,16 @@ def call(config_repo){
         }
         options {
             disableConcurrentBuilds()
-        }    
+        }
         environment {
-            dockerImageName = "lsstts/conda_package_builder:latest"
-            container_name = "salobj_${BUILD_ID}_${JENKINS_NODE_COOKIE}"
             PYPI_CREDS = credentials("pypi")
-            OSPL_HOME="/opt/OpenSpliceDDS/V6.10.4/HDE/x86_64.linux"
         }
         parameters {
             string(defaultValue: '\'\'', description: 'The IDL Version', name: 'idl_version')
             string(defaultValue: '\'\'', description: 'The XML Version', name: 'xml_version')
             string(defaultValue: '\'\'', description: 'The SAL Version', name: 'sal_version')
             booleanParam(defaultValue: false, description: "Are we going on to building the CSC package after salobj?", name: 'buildCSCConda')
-            
+
         }
         stages {
             stage("Clone configuration repository") {
@@ -79,7 +76,7 @@ def call(config_repo){
                     buildingTag()
                 }
                 steps {
-                    withEnv(["HOME=${env.WORKSPACE}"]) {
+                    withEnv(["WHOME=${env.WORKSPACE}"]) {
                         script {
                             csc.build_salobj_conda("main", "${concatVersion}")
                         }
@@ -93,7 +90,7 @@ def call(config_repo){
                     }
                 }
                 steps {
-                    withEnv(["HOME=${env.WORKSPACE}"]) {
+                    withEnv(["WHOME=${env.WORKSPACE}"]) {
                         script {
                             csc.build_salobj_conda("dev", "${concatVersion}")
                         }
@@ -109,7 +106,7 @@ def call(config_repo){
                 }
                 steps {
                     withCredentials([usernamePassword(credentialsId: 'CondaForge', passwordVariable: 'anaconda_pass', usernameVariable: 'anaconda_user')]) {
-                        withEnv(["HOME=${env.WORKSPACE}"]) {
+                        withEnv(["WHOME=${env.WORKSPACE}"]) {
                             sh """
                             source /home/saluser/miniconda3/bin/activate
                             anaconda login --user ${anaconda_user} --password ${anaconda_pass}
@@ -129,7 +126,7 @@ def call(config_repo){
                 }
                 steps {
                     withCredentials([usernamePassword(credentialsId: 'CondaForge', passwordVariable: 'anaconda_pass', usernameVariable: 'anaconda_user')]) {
-                        withEnv(["HOME=${env.WORKSPACE}"]) {
+                        withEnv(["WHOME=${env.WORKSPACE}"]) {
                             sh """
                             source /home/saluser/miniconda3/bin/activate
                             anaconda login --user ${anaconda_user} --password ${anaconda_pass}
@@ -160,7 +157,7 @@ def call(config_repo){
                             conda install -q -y setuptools_scm > /dev/null &&
                             python -c 'from setuptools_scm import get_version; print(get_version())'
                             """).trim()
-                            
+
 
                             echo "Starting the CSC_Conda_broker/develop job; idl_version: ${idl_version}, salobj_version: ${SALOBJVERSION}, XML_Version: ${xml_version}, SAL_Version: ${sal_version}"
                             build job: 'CSC_Conda_Broker', parameters: [\
@@ -178,7 +175,7 @@ def call(config_repo){
         }//stages
         post {
             cleanup {
-                withEnv(["HOME=${env.WORKSPACE}"]) {
+                withEnv(["WHOME=${env.WORKSPACE}"]) {
                     sh 'chown -R 1003:1003 ${HOME}/'
                 }
             }
@@ -193,7 +190,7 @@ def call(config_repo){
                     def userId = "U6BCN6H43"
                     slackSend(color: "danger", message: "<@$userId> ${JOB_NAME} has suffered a regression ${BUILD_URL}", channel: "#jenkins-builds, @$userId")
                 }
-                
+
             }
             fixed {
                 script {


### PR DESCRIPTION
* In vars/CondaPipeline.groovy:
  * Don't setup ospl_home, this must come from the setup script in the conda builder container.
  * Stop overriding `HOME` environment variable as this interferes with the setup script in the conda builder. Uses `WHOME` (work home) instead.
* In vars/IdlPipeline.groovy:
  * Don't setup OSPL_HOME, this must come from the setup script in the conda builder container.
  * Stop overriding `HOME` environment variable as this interferes with the setup script in the conda builder. Uses `WHOME` (work home) instead.
  * Remove some unused environment variables.
* In src/org/lsst/ts/jenkins/components/Csc.groovy:
  * `source /home/saluser/.setup.sh` instead of inline setup.