### PR TITLE
Tickets/osw754: Make Register and Delete KafkaTopics scripts fully featured

### DIFF
--- a/doc/documenteer.toml
+++ b/doc/documenteer.toml
@@ -1,0 +1,5 @@
+[project]
+title = "ts_jenkins_shared_library"
+copyright = "2015-2022 Association of Universities for Research in Astronomy, Inc. (AURA)"
+base_url = "https://ts-jenkins-shared-library.lsst.io"
+github_url = "https://github.com/lsst/ts_jenkins_shared_library"

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,1 +1,1 @@
-documenteer[pipelines]
+documenteer[pipelines,guide]>=1.4,<2

--- a/vars/deleteKafkaTopics.groovy
+++ b/vars/deleteKafkaTopics.groovy
@@ -27,8 +27,8 @@ def call(String XML_VERSION, String SUBNAME, Boolean FORCE, String COMPONENTS) {
             fi
             echo I am deleting topics for "$COMPONENTS" components with the "$SUBNAME" subname using XML v${XML_VERSION}
             source ~/miniconda3/bin/activate
-            conda install -y -c lsstts/label/dev "ts-xml>=${XML_VERSION}"
-            conda install -y -c lsstts "ts-salobj>=8"
+            conda install -qy -c lsstts/label/dev "ts-xml>=${XML_VERSION}"
+            conda install -qy -c lsstts "ts-salobj>=8"
             csc_list="$COMPONENTS"
             echo CSCs: \$csc_list
             if [ "\${csc_list,,}" == "all" ]; then

--- a/vars/deleteKafkaTopics.groovy
+++ b/vars/deleteKafkaTopics.groovy
@@ -1,18 +1,42 @@
 // vars/deleteKafkaTopics.groovy
-def call(String XML_VERSION, String SUBNAME, Boolean FORCE) {
+def call(String XML_VERSION, String SUBNAME, Boolean FORCE, String COMPONENTS) {
+    // Attributes
+    // ----------
+    //
+    // XML_VERSION : `string`
+    //     Defines the version of XML that SalObj uses to register the topics.
+    // SUBNAME : `string`
+    //     Defines the topic subname to delete..
+    // FORCE : `boolean`
+    //     Required when deleting the `sal` subname, which is a protected value.
+    // COMPONENTS : `string`
+    //     Space-separated, case-sensitive list of CSCs, e.g Test Script ScriptQueue,
+    //     or ALL if creating topics for all components.
+    //
     script {
         sh """
-            echo ${FORCE}
-            if [ '${FORCE}' = true ]; then
+            echo I am deleting topics for "$COMPONENTS" components with the "$SUBNAME" subname using XML v${XML_VERSION}
+            source ~/miniconda3/bin/activate
+            conda install -qy -c lsstts/label/dev "ts-xml>=${XML_VERSION}"
+            conda install -qy -c lsstts "ts-salobj>=8"
+            echo Force: ${FORCE}
+            if [ '${FORCE}' == true ]; then
                 flag='--force'
             else
                 flag=''
             fi
-            echo I am deleting the '${SUBNAME}' subname for topics defined using XML v${XML_VERSION}
+            echo I am deleting topics for "$COMPONENTS" components with the "$SUBNAME" subname using XML v${XML_VERSION}
             source ~/miniconda3/bin/activate
             conda install -y -c lsstts/label/dev "ts-xml>=${XML_VERSION}"
             conda install -y -c lsstts "ts-salobj>=8"
-            delete_topics --subname=${SUBNAME} --all \$flag
+            csc_list="$COMPONENTS"
+            echo CSCs: \$csc_list
+            if [ "\${csc_list,,}" == "all" ]; then
+                cscs="--all"
+            else
+                cscs="${COMPONENTS}"
+            fi
+            delete_topics --subname=${SUBNAME} \$cscs \$flag
         """
     }
 }

--- a/vars/registerKafkaTopics.groovy
+++ b/vars/registerKafkaTopics.groovy
@@ -13,8 +13,8 @@ def call(String XML_VERSION, String COMPONENTS) {
         sh """
             echo I am registering topics for "$COMPONENTS" components with the "$LSST_TOPIC_SUBNAME" subname using XML v$XML_VERSION
             source ~/miniconda3/bin/activate
-            conda install -y -c lsstts/label/dev "ts-xml>=$XML_VERSION"
-            conda install -y -c lsstts "ts-salobj>=8"
+            conda install -qy -c lsstts/label/dev "ts-xml>=$XML_VERSION"
+            conda install -qy -c lsstts "ts-salobj>=8"
             csc_list="$COMPONENTS"
             if [ "\${csc_list,,}" == "all" ]; then
                 cscs="--all"

--- a/vars/registerKafkaTopics.groovy
+++ b/vars/registerKafkaTopics.groovy
@@ -1,12 +1,27 @@
 // vars/registerKafkaTopics.groovy
-def call(String XML_VERSION) {
+def call(String XML_VERSION, String COMPONENTS) {
+    // Attributes
+    // ----------
+    //
+    // XML_VERSION : `string`
+    //     Defines the version of XML that SalObj uses to register the topics.
+    // COMPONENTS : `string`
+    //     Space-separated, case-sensitive list of CSCs, e.g Test Script ScriptQueue,
+    //     or ALL if creating topics for all components.
+    //
     script {
         sh """
-            echo I am registering the $LSST_TOPIC_SUBNAME subname for topics defined using XML v${XML_VERSION}
+            echo I am registering topics for "$COMPONENTS" components with the "$LSST_TOPIC_SUBNAME" subname using XML v$XML_VERSION
             source ~/miniconda3/bin/activate
-            conda install -y -c lsstts/label/dev "ts-xml>=${XML_VERSION}"
+            conda install -y -c lsstts/label/dev "ts-xml>=$XML_VERSION"
             conda install -y -c lsstts "ts-salobj>=8"
-            create_topics --all
+            csc_list="$COMPONENTS"
+            if [ "\${csc_list,,}" == "all" ]; then
+                cscs="--all"
+            else
+                cscs="$COMPONENTS"
+            fi
+            create_topics \$cscs
         """
     }
 }


### PR DESCRIPTION
* Both scripts now accept the same inputs as the SalObj scripts they wrap, so they can register and delete ALL topics or for a subset of CSCs.
* Add the -q flag to the conda install commands to suppress the download progress text.