### PR TITLE
Add an option to mount the rubin sim data directory to the develop and conda builds.

### DIFF
--- a/vars/CondaPipeline.groovy
+++ b/vars/CondaPipeline.groovy
@@ -5,6 +5,7 @@ def call(Object... varargs){
     // Create a conda build pipeline
     // Define default variables
     upload_dev=false
+    mount_rubin_sim_data=false
     // Check if map is first for named parameters
     if (varargs[0] instanceof Map) {
         pipeline_args = varargs[0]
@@ -26,6 +27,9 @@ def call(Object... varargs){
         if(pipeline_args["upload_dev"]){
             upload_dev=pipeline_args.upload_dev.toBoolean()
         }
+        if(pipeline_args["mount_rubin_sim_data"]){
+            mount_rubin_sim_data=pipeline_args.mount_rubin_sim_data.toBoolean()
+        }
     }
     // If not map then assume ordered parameters
     // Mixing these are not supported nor handled
@@ -41,6 +45,9 @@ def call(Object... varargs){
         }
         if (varargs.length == 5){
             upload_dev = varargs[4]
+        }
+        if (varargs.length == 6){
+            mount_rubin_sim_data = varargs[5]
         }
     }
     Csc csc = new Csc()
@@ -78,7 +85,7 @@ def call(Object... varargs){
                 image image_value
                 alwaysPull true
                 label "${params.build_agent}"
-                args arg_str.concat("--entrypoint='' -e LSST_KAFKA_BROKER_ADDR='35.85.18.232:9092' -e LSST_SCHEMA_REGISTRY_URL='http://35.85.18.232:8081'")
+                args arg_str.concat("--entrypoint='' -e LSST_KAFKA_BROKER_ADDR='35.85.18.232:9092' -e LSST_SCHEMA_REGISTRY_URL='http://35.85.18.232:8081' ${mount_rubin_sim_data ? '-v /home/jenkins/workspace/rubin_sim_data:/home/saluser/rubin_sim_data' : ''}")
                 registryUrl registry_url
                 registryCredentialsId registry_credentials_id
             }

--- a/vars/DevelopPipeline.groovy
+++ b/vars/DevelopPipeline.groovy
@@ -10,7 +10,8 @@ def call(Map pipeline_args = [:]) {
         use_pyside6: true,
         require_git_lfs: false,
         require_scons: false,
-        full_history: true
+        full_history: true,
+        mount_rubin_sim_data: false
     ]
     pipeline_args = defaultArgs << pipeline_args
     if((!pipeline_args["name"]) || (!pipeline_args["module_name"] == null)) {
@@ -41,7 +42,7 @@ def call(Map pipeline_args = [:]) {
             docker {
                 alwaysPull true
                 image 'lsstts/develop-env:develop'
-                args "--entrypoint='' -e LSST_KAFKA_BROKER_ADDR='35.85.18.232:9092' -e LSST_SCHEMA_REGISTRY_URL='http://35.85.18.232:8081'"
+                args "--entrypoint='' -e LSST_KAFKA_BROKER_ADDR='35.85.18.232:9092' -e LSST_SCHEMA_REGISTRY_URL='http://35.85.18.232:8081' ${pipeline_args.mount_rubin_sim_data ? '-v /home/jenkins/workspace/rubin_sim_data:/home/saluser/rubin_sim_data' : ''}"
                 label "${params.build_agent}"
             }
         }


### PR DESCRIPTION
Mounting the Rubin sim data directory can considerable speedup the Scheduler builds and avoids downloading a few GB of data from USDF for every run.

This is mainly used for the ts_scheduler builds but can be later expanded for any builds that use rubin_scheduler, the feature based scheduler codebase.